### PR TITLE
import topai_utiles bug 

### DIFF
--- a/mitmproxy2swagger/mitmproxy2swagger.py
+++ b/mitmproxy2swagger/mitmproxy2swagger.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Converts a mitmproxy dump file to a swagger schema."""
-from topeai_utils import is_param
+from .topeai_utils import is_param
 import argparse
 import json
 import os


### PR DESCRIPTION
When you use from .topeai_utils import is_param (with the dot prefix), you're using a relative import. The dot indicates "import from the current package." This works because:

The mitmproxy2swagger.py file is part of a package (likely the mitmproxy2swagger package)
The topeai_utils.py file is in the same package directory
When you try from topeai_utils import is_param (without the dot), you're using an absolute import. This tells Python to look for a top-level package named topeai_utils in the Python path, not within the current package. Since there's no top-level package with this name, the import fails.